### PR TITLE
change from binary to tar.gz for goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,5 +29,8 @@ builds:
       - arm64
 
 archives:
-  - format: binary
+  - format: tar.gz
     name_template: '{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}'
+    format_overrides:
+      - goos: windows
+        format: zip


### PR DESCRIPTION
This is needed to add rename-pvc as a krew plugin