### PR TITLE
remove deprecated errors pkg

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/stackitcloud/rename-pvc
 go 1.18
 
 require (
-	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.5.0
 	k8s.io/api v0.24.2
 	k8s.io/apimachinery v0.24.2
@@ -52,6 +51,7 @@ require (
 	github.com/onsi/ginkgo v1.16.5 // indirect
 	github.com/onsi/gomega v1.17.0 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect

--- a/pkg/renamepvc/renamepvc.go
+++ b/pkg/renamepvc/renamepvc.go
@@ -3,13 +3,13 @@ package renamepvc
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -149,7 +149,7 @@ func (o *renamePVCOptions) checkIfMounted(ctx context.Context, pvc *corev1.Persi
 		for vol := range podList.Items[pod].Spec.Volumes {
 			volume := &podList.Items[pod].Spec.Volumes[vol]
 			if volume.PersistentVolumeClaim != nil && volume.PersistentVolumeClaim.ClaimName == pvc.Name {
-				return errors.Wrapf(ErrVolumeMounted, "pod %s", podList.Items[pod].Name)
+				return fmt.Errorf("%w in pod \"%s\"", ErrVolumeMounted, podList.Items[pod].Name)
 			}
 		}
 	}

--- a/pkg/renamepvc/renamepvc_test.go
+++ b/pkg/renamepvc/renamepvc_test.go
@@ -2,9 +2,9 @@ package renamepvc
 
 import (
 	"context"
+	"errors"
 	"testing"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -230,7 +230,7 @@ func checkRename(ctx context.Context, o *renamePVCOptions) error {
 
 	if pv.Spec.ClaimRef.Name != newPVC.Name &&
 		pv.Spec.ClaimRef.Namespace != newPVC.Namespace {
-		return errors.New("pv claimRef wrong")
+		return errors.New("pv claimRef wrong") // nolint: goerr113 // in test okay
 	}
 
 	_, err = o.k8sClient.CoreV1().PersistentVolumeClaims(o.targetNamespace).Get(ctx, o.newName, metav1.GetOptions{})


### PR DESCRIPTION
https://github.com/pkg/errors is only used in one error wrap. 
The pkg is archived so I removed it and to the error wrap "manually"