### PR TITLE
Update go version and golangci lint

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.24.x
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.22.x]
+        go-version: [1.24.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 
@@ -60,7 +60,7 @@ jobs:
   test-kind:
     strategy:
       matrix:
-        go-version: [1.22.x]
+        go-version: [1.24.x]
     runs-on: ubuntu-latest
 
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,58 +1,9 @@
-linters-settings:
-  dupl:
-    threshold: 100
-  funlen:
-    lines: 100
-    statements: 50
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - dupImport # https://github.com/go-critic/go-critic/issues/845
-      - ifElseChain
-      - octalLiteral
-      - whyNoLint
-      - wrapperFunc
-  gocyclo:
-    min-complexity: 15
-  # gci:
-  #   local-prefixes: insert your package name here
-  # goimports:
-  #   local-prefixes: insert your package name here
-  golint:
-    min-confidence: 0
-  gomnd:
-    settings:
-      mnd:
-        # don't include the "operation" and "assign"
-        checks:
-          - argument
-          - case
-          - condition
-          - return
-  govet:
-    check-shadowing: false # too many false positives when shadowing err
-  lll:
-    line-length: 140
-  misspell:
-    locale: US
-  nolintlint:
-    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
-    allow-unused: false # report any unused nolint directives
-    require-explanation: true # require an explanation for nolint directives
-    require-specific: true # require nolint directives to be specific about which linter is being skipped
-
+version: "2"
+run:
+  issues-exit-code: 1
+  tests: true
 linters:
-  # please, do not use `enable-all`: it's deprecated and will be removed soon.
-  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
-  disable-all: true
+  default: none
   enable:
     - bodyclose
     - copyloopvar
@@ -61,15 +12,13 @@ linters:
     - err113
     - exhaustive
     - funlen
+    - gochecknoglobals
     - gochecknoinits
     - goconst
     - gocritic
     - gocyclo
-    - gofmt
-    - goimports
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - lll
@@ -78,49 +27,74 @@ linters:
     - nakedret
     - noctx
     - nolintlint
+    - prealloc
     - revive
     - staticcheck
-    - stylecheck
-    - typecheck
     - unconvert
     - unparam
     - unused
     - whitespace
-    - gochecknoglobals
-    - prealloc
-
-  # don't enable:
-  # - asciicheck
-  # - errcheck # Disabled since it detects defers that do not check errors. This is a standard pattern.
-  #              see https://github.com/kisielk/errcheck/issues/55
-  # - scopelint
-  # - gocognit
-  # - godot
-  # - godox
-  # - golint # deprecated
-  # - interfacer
-  # - nestif
-  # - testpackage
-
-  # - wsl
-
-issues:
-  # Excluding configuration per-path, per-linter, per-text and per-source
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - gochecknoglobals
-        - gosec
-        - mnd
-        - noctx
-        - dogsled
-
-    # https://github.com/go-critic/go-critic/issues/926
-    - linters:
-        - gocritic
-      text: "unnecessaryDefer:"
-
-run:
-  timeout: 10m
-  issues-exit-code: 1
-  tests: true
+  settings:
+    dupl:
+      threshold: 100
+    funlen:
+      lines: 100
+      statements: 50
+    goconst:
+      min-len: 2
+      min-occurrences: 2
+    gocritic:
+      disabled-checks:
+        - dupImport
+        - ifElseChain
+        - octalLiteral
+        - whyNoLint
+        - wrapperFunc
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+    gocyclo:
+      min-complexity: 15
+    lll:
+      line-length: 140
+    misspell:
+      locale: US
+    nolintlint:
+      require-explanation: true
+      require-specific: true
+      allow-unused: false
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - dogsled
+          - gochecknoglobals
+          - gosec
+          - mnd
+          - noctx
+        path: _test\.go
+      - linters:
+          - gocritic
+        text: 'unnecessaryDefer:'
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,7 @@ SHELL=/bin/bash -e -o pipefail
 PWD = $(shell pwd)
 
 # constants
-GOLANGCI_VERSION = 1.62.2
-
+GOLANGCI_VERSION = 2.1.5
 all: git-hooks  tidy ## Initializes all tools
 
 out:

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ lint-reports: out/lint.xml
 
 .PHONY: out/lint.xml
 out/lint.xml: $(GOLANGCI_LINT) out download
-	@$(GOLANGCI_LINT) run ./... --out-format checkstyle | tee "$(@)"
+	@$(GOLANGCI_LINT) run ./... --output.checkstyle.path stdout | tee "$(@)"
 
 test: ## Runs all tests
 	@go test $(ARGS) ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stackitcloud/rename-pvc
 
-go 1.23.4
+go 1.24
 
 require (
 	github.com/spf13/cobra v1.9.1

--- a/pkg/renamepvc/renamepvc_test.go
+++ b/pkg/renamepvc/renamepvc_test.go
@@ -230,7 +230,7 @@ func checkRename(ctx context.Context, o *renamePVCOptions) error {
 
 	if pv.Spec.ClaimRef.Name != newPVC.Name &&
 		pv.Spec.ClaimRef.Namespace != newPVC.Namespace {
-		return errors.New("pv claimRef wrong") //nolint: goerr113 // in test okay
+		return errors.New("pv claimRef wrong") //nolint: err113 // in test okay
 	}
 
 	_, err = o.k8sClient.CoreV1().PersistentVolumeClaims(o.targetNamespace).Get(ctx, o.newName, metav1.GetOptions{})


### PR DESCRIPTION
This PR update the go and golanci lint version.
For the golanci lint version was a config migration needed. 

