### PR TITLE
Add permissions for Release GH action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*.*.*"
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`goreleaser` needs the `content: write` permission. See https://github.com/goreleaser/goreleaser-action?tab=readme-ov-file#limitation

This is the reason the pipeline failed: https://github.com/stackitcloud/rename-pvc/actions/runs/17756582000

