### PR TITLE
Add github action to test goreleaser config

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:
-          version: latest
+          version: v2.15.4
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -107,3 +107,28 @@ jobs:
 
       - name: Check rename
         run: kubectl get pvc pvc-new
+  test-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: 1.26.x
+
+      - name: Validate goreleaser config
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          version: v2.15.4
+          args: check
+
+      - name: Create snapshot release (dry-run)
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          version: v2.15.4
+          args: release --snapshot --clean

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,9 @@
+version: 2
+
 project_name: rename-pvc
 
 snapshot:
-  name_template: '{{ .Tag }}-SNAPSHOT'
+  version_template: '{{ .Tag }}-SNAPSHOT'
 
 before:
   hooks:
@@ -29,8 +31,8 @@ builds:
       - arm64
 
 archives:
-  - format: tar.gz
+  - formats: ["tar.gz"]
     name_template: '{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}'
     format_overrides:
       - goos: windows
-        format: zip
+        formats: ["zip"]


### PR DESCRIPTION
This PR pins the version for goreleaser and adds a config check. So we get information about deprecated config options early. Renovate will bump the goreleaser version in the actions.

Additionally it builds the release without publish (`--snapshot`)
```
    --snapshot             Generate an unversioned snapshot release, skipping all validations and without publishing any artifacts (implies --skip=announce,publish,validate)
```

This PR also addresses the already deprecated fields.